### PR TITLE
Allow for closing of TCP Socket connection + Formatting cleanup

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1,6 +1,6 @@
-const dgram  = require('dgram')
-var qs = require('querystring')
-var url = require('url')
+const dgram = require('dgram')
+const qs = require('querystring')
+const url = require('url')
 const EventEmitter = require('events')
 
 const Yeelight = require('./Yeelight')

--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -8,7 +8,7 @@ class Yeelight extends EventEmitter {
         this.ip = config.ip
         this.port = config.port
         this.client = net.Socket()
-        this.client.setEncoding("utf8")
+        this.client.setEncoding('utf8')
         this.connected = false
     }
 
@@ -18,7 +18,7 @@ class Yeelight extends EventEmitter {
      */
     _connect() {
         this.client.connect(this.port, this.ip)
-        
+
         this.client.on('close', () => {
             this.emit('close', {
                 id: this.id,
@@ -91,8 +91,8 @@ class Yeelight extends EventEmitter {
      * Close TCP connection to lamp
      */
     closeConnection() {
-        this.client.destroy();
-        this.connected = false;
+        this.client.destroy()
+        this.connected = false
     }
 
     /**
@@ -101,7 +101,7 @@ class Yeelight extends EventEmitter {
     toggle() {
         return this._sendCommand({
             method: 'toggle',
-            params: [],
+            params: []
         })
     }
 
@@ -111,7 +111,7 @@ class Yeelight extends EventEmitter {
     bg_toggle() {
         return this._sendCommand({
             method: 'bg_toggle',
-            params: [],
+            params: []
         })
     }
 
@@ -121,10 +121,10 @@ class Yeelight extends EventEmitter {
     dev_toggle() {
         return this._sendCommand({
             method: 'dev_toggle',
-            params: [],
+            params: []
         })
     }
-    
+
     /**
      * This method is used to retrieve the current properties of the smart LED.
      * @param {String} first The property of the light you want to get
@@ -148,10 +148,10 @@ class Yeelight extends EventEmitter {
         return this._sendCommand({
             method: 'set_ct_abx',
             params: [
-                this._constrain(ct_value, 1700, 6500), 
-                this._ifValid(effect, ['smooth', 'sudden'], 'smooth'), 
-                duration || 500,
-            ],
+                this._constrain(ct_value, 1700, 6500),
+                this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
+                duration || 500
+            ]
         })
     }
 
@@ -159,10 +159,10 @@ class Yeelight extends EventEmitter {
      * Set the RGB color of the light
      * @param {Array} rgb Array of R,G,B as values between 0 and 255
      * @param {String} effect Either 'smooth' or 'sudden'
-     * @param {Number} duration 
+     * @param {Number} duration
      */
-    set_rgb(rgb = [255,255,255], effect = 'smooth', duration = 500) {
-        const rgbValue = 
+    set_rgb(rgb = [255, 255, 255], effect = 'smooth', duration = 500) {
+        const rgbValue =
             (this._constrain(rgb[0], 0, 255) * 65536) +
             (this._constrain(rgb[1], 0, 255) * 256) +
             (this._constrain(rgb[2], 0, 255))
@@ -170,9 +170,9 @@ class Yeelight extends EventEmitter {
             method: 'set_rgb',
             params: [
                 rgbValue,
-                this._ifValid(effect, ['smooth', 'sudden'], 'smooth'), 
+                this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
                 duration || 500
-            ],
+            ]
         })
     }
 
@@ -190,8 +190,8 @@ class Yeelight extends EventEmitter {
                 this._constrain(hue, 0, 359),
                 this._constrain(sat, 0, 100),
                 this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
-                duration || 500,
-            ],
+                duration || 500
+            ]
         })
     }
 
@@ -209,13 +209,13 @@ class Yeelight extends EventEmitter {
                 this._constrain(hue, 0, 359),
                 this._constrain(sat, 0, 100),
                 this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
-                duration || 500,
-            ],
+                duration || 500
+            ]
         })
     }
 
     /**
-     * This method is used to change the brightness of the Smart LED 
+     * This method is used to change the brightness of the Smart LED
      * @param {Number} brightness The desired brightness between 1 and 100
      * @param {String} effect Either the string 'sudden' or 'smooth'
      * @param {Number} duration the time in ms for the transition to take effect
@@ -226,13 +226,13 @@ class Yeelight extends EventEmitter {
             params: [
                 this._constrain(brightness, 1, 100),
                 this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
-                duration || 500,
-            ],
+                duration || 500
+            ]
         })
     }
 
     /**
-     * This method is used to change the brightness of the background Smart LED 
+     * This method is used to change the brightness of the background Smart LED
      * @param {Number} brightness The desired brightness between 1 and 100
      * @param {String} effect Either the string 'sudden' or 'smooth'
      * @param {Number} duration the time in ms for the transition to take effect
@@ -243,8 +243,8 @@ class Yeelight extends EventEmitter {
             params: [
                 this._constrain(brightness, 1, 100),
                 this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
-                duration || 500,
-            ],
+                duration || 500
+            ]
         })
     }
 
@@ -262,8 +262,8 @@ class Yeelight extends EventEmitter {
                 this._ifValid(power, ['on', 'off'], 'on'),
                 this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
                 duration || 500,
-                this._ifValid(mode, [0,1,2,3,4,5], 0)
-            ],
+                this._ifValid(mode, [0, 1, 2, 3, 4, 5], 0)
+            ]
         })
     }
 
@@ -281,8 +281,8 @@ class Yeelight extends EventEmitter {
                 this._ifValid(power, ['on', 'off'], 'on'),
                 this._ifValid(effect, ['smooth', 'sudden'], 'smooth'),
                 duration || 500,
-                this._ifValid(mode, [0,1,2,3,4,5], 0)
-            ],
+                this._ifValid(mode, [0, 1, 2, 3, 4, 5], 0)
+            ]
         })
     }
 
@@ -292,7 +292,7 @@ class Yeelight extends EventEmitter {
     set_default() {
         return this._sendCommand({
             method: 'set_default',
-            params: [],
+            params: []
         })
     }
 
@@ -302,12 +302,12 @@ class Yeelight extends EventEmitter {
     bg_set_default() {
         return this._sendCommand({
             method: 'bg_set_default',
-            params: [],
+            params: []
         })
     }
 
     /**
-     * 
+     *
      * @param {Number} count The number of state changes before color flow stops. 0 = infinite
      * @param {Number} action The action after stopping CF. 0 = revert to previous state, 1 stay at state when stopped, 2 = turn off smart LED
      * @param {Array} flow A series of tuples defining the [duration, mode, value, brightness]
@@ -330,7 +330,7 @@ class Yeelight extends EventEmitter {
             method: 'start_cf',
             params: [
                 count || 0,
-                this._ifValid(action, [0,1,2], 0),
+                this._ifValid(action, [0, 1, 2], 0),
                 flowExpression
             ]
         })
@@ -342,7 +342,7 @@ class Yeelight extends EventEmitter {
     stop_cf() {
         return this._sendCommand({
             method: 'stop_cf',
-            params: [],
+            params: []
         })
     }
 
@@ -372,7 +372,7 @@ class Yeelight extends EventEmitter {
             params: [
                 this._ifValid(type, [0], 0),
                 value || 1
-            ],
+            ]
         })
     }
 
@@ -385,7 +385,7 @@ class Yeelight extends EventEmitter {
             methods: 'cron_get',
             params: [
                 this._ifValid(type, [0], 0)
-            ],
+            ]
         })
     }
 
@@ -398,7 +398,7 @@ class Yeelight extends EventEmitter {
             method: 'cron_del',
             params: [
                 this._ifValid(type, [0], 0)
-            ],    
+            ]
         })
     }
 
@@ -408,15 +408,15 @@ class Yeelight extends EventEmitter {
      * @param {String} prop The property to adjust
      */
     set_adjust(action = 'circle', prop = 'bright') {
-        const validatedAction = prop === 'color' 
-            ? 'circle' 
+        const validatedAction = prop === 'color'
+            ? 'circle'
             : this._ifValid(action, ['increase', 'decrease', 'circle'], 'circle')
         return this._sendCommand({
             method: 'set_adjust',
             params: [
                 validatedAction,
                 this._ifValid(prop, ['bright', 'ct', 'color'], 'circle')
-            ],    
+            ]
         })
     }
 
@@ -432,8 +432,8 @@ class Yeelight extends EventEmitter {
             params: [
                 this._ifValid(action, [0, 1], 0),
                 host,
-                port,
-            ],
+                port
+            ]
         })
     }
 

--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -88,6 +88,14 @@ class Yeelight extends EventEmitter {
     }
 
     /**
+     * Close TCP connection to lamp
+     */
+    closeConnection() {
+        this.client.destroy();
+        this.connected = false;
+    }
+
+    /**
      * Toggle the state of the main light
      */
     toggle() {

--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -74,7 +74,7 @@ class Yeelight extends EventEmitter {
      * @param {Array} haystack Array to search against
      */
     _inArray(needle = '', haystack = []) {
-        return haystack.constructor == Array && haystack.includes(needle) != false
+        return Array.isArray(haystack) && haystack.includes(needle)
     }
 
     /**

--- a/tests/yeelight.test.js
+++ b/tests/yeelight.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const chai   = require('chai')
+const chai = require('chai')
     , expect = chai.expect
-    , sinon  = require('sinon')
+    , sinon = require('sinon')
 
 const Yeelight = require('../').Yeelight
 
@@ -82,13 +82,13 @@ describe('Yeelight Class', () => {
         })
         yeelight.emit('close', {})
     })
-   
+
     it('should touch the command sneder with toggle', () => {
         yeelight.toggle()
     })
 
     it('should close the tcp connection', () => {
-        yeelight.closeConnection();
-        expect(yeelight.connected).to.equal(false);
+        yeelight.closeConnection()
+        expect(yeelight.connected).to.equal(false)
     })
 })

--- a/tests/yeelight.test.js
+++ b/tests/yeelight.test.js
@@ -75,11 +75,13 @@ describe('Yeelight Class', () => {
     })
 
     it('should emit values coming from the close listener', (done) => {
-        yeelight.on('close', (data) => {
+        function onClose(data) {
             expect(yeelight.connected).to.equal(false)
             expect(data).to.be.an('object')
+            yeelight.removeListener('close', onClose);
             done()
-        })
+        }
+        yeelight.on('close', onClose)
         yeelight.emit('close', {})
     })
 

--- a/tests/yeelight.test.js
+++ b/tests/yeelight.test.js
@@ -86,4 +86,9 @@ describe('Yeelight Class', () => {
     it('should touch the command sneder with toggle', () => {
         yeelight.toggle()
     })
+
+    it('should close the tcp connection', () => {
+        yeelight.closeConnection();
+        expect(yeelight.connected).to.equal(false);
+    })
 })


### PR DESCRIPTION
When using this library in an ExpressJS application, I noticed that after creating a Yeelight object in route handlers to process user requests, I had no option to close the connection it opened to a lamp.
This meant that after 4 requests to my server, 4 TCP connections had been opened and any further requests were rejected (as defined in the official Yeelight docs).

I added a simple closeConnection method to the Yeelight object to allow the library user to close the TCP  connection at will, should their use case require it (like in my case).

I also appended some commits unifying the code formatting of the library since I noticed some inconsistencies and stray whitespaces. I know this is an opinionated topic, but I tried to find what style the majority of the code already used and enforced that across the board.