### PR TITLE
Changes to Yeelight Props and _sendCommand listeners

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -54,7 +54,20 @@ class Client extends EventEmitter {
                     const yeelight = new Yeelight({
                         id: data['id'],
                         ip: urlObj['hostname'],
-                        port: urlObj['port']
+                        port: urlObj['port'],
+                        name: Buffer.from(data['name'], 'base64').toString(),
+                        model: data['model'],
+                        fw_ver: data['fw_ver'],
+                        methods: data['support'].split(' '),
+                        state: {
+                            on: data['power'] == 'on' ? true : false,
+                            brightness: data['bright'],
+                            color_mode: data['color_mode'],
+                            color_temp: data['ct'],
+                            rgb: data['rgb'],
+                            hue: data['hue'],
+                            sat: data['sat']
+                        }
                     })
                     this.lights.push(yeelight)
                     if (callback) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -52,7 +52,7 @@ class Client extends EventEmitter {
                 if (location) {
                     const urlObj = url.parse(location)
                     const yeelight = new Yeelight({
-                        id: data['id'],
+                        id: parseInt(data['id'], 16),
                         ip: urlObj['hostname'],
                         port: urlObj['port'],
                         name: Buffer.from(data['name'], 'base64').toString(),

--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -4,11 +4,16 @@ const net = require('net')
 class Yeelight extends EventEmitter {
     constructor(config = {}) {
         super()
-        this.id = config.id || 0
+        this.id = parseInt(config.id, 16) || 0
         this.ip = config.ip
         this.port = config.port
+        this.name = config.name
+        this.model = config.model
+        this.fw_ver = config.fw_ver
+        this.methods = config.methods
+        this.state = config.state
         this.client = net.Socket()
-        this.client.setEncoding('utf8')
+        this.client.setEncoding("utf8")
         this.connected = false
     }
 
@@ -44,16 +49,24 @@ class Yeelight extends EventEmitter {
 
         return new Promise((resolve, reject) => {
             this.client.write(JSON.stringify(objectCommand) + '\r\n')
-            this.client.on('error', error => {
+            const handleError = error => {
+                removeListeners()
                 reject(error)
-            })
-            this.client.on('data', data => {
+            }
+            const handleData = data => {
                 const regex = new RegExp('{"id":' + objectCommand.id + '.*}', 'g')
                 const match = regex.exec(data)
                 if (match) {
+                    removeListeners()
                     resolve(match[0])
                 }
-            })
+            }
+            const removeListeners = () => {
+                this.client.removeListener('error', handleError)
+                this.client.removeListener('data', handleData)
+            }
+            this.client.on('error', handleError)
+            this.client.on('data', handleData)
         })
     }
 

--- a/lib/Yeelight.js
+++ b/lib/Yeelight.js
@@ -4,7 +4,7 @@ const net = require('net')
 class Yeelight extends EventEmitter {
     constructor(config = {}) {
         super()
-        this.id = parseInt(config.id, 16) || 0
+        this.id = config.id || 0
         this.ip = config.ip
         this.port = config.port
         this.name = config.name


### PR DESCRIPTION
Changes made in this pull request

1. I have added extra properties to the Yeelight class based on the information made available by the light. The datagram sent in response to ssdp:discover includes the following extra properties which has been captured and added to the Yeelight class:

- **id**: Converted from a hex string into an integer value.
- **name**: Converted from base64 into utf-8 string using Node.js Buffer.toString().
- **model**: Model of light.
- **fw_ver**: The device's firmware version.
- **methods**: An array of supported methods (from the documented methods)
- **state**: An object of the current state of the light with the following shape: 
{
power: _boolean_,
bright: _int_,
color_mode: _int_,
color_temp: _int_,
rgb: _int_,
hue: _int_,
sat: _int_
}

2. I have also adjusted the **_sendCommand** method of the Yeelight class to fix a warning created by sending more than 10 commands in a session. It appears that when a command is resolved or rejected, the listener persists. I have made a change which removes the 'data' and 'error' listeners when a command is resolved or rejected.

Feel free to adjust some of what I've done here as this is my first PR. These are just some changed I found myself making to the library when incorporating it into my app. I'd like to be able to improve this great implementation.