### PR TITLE
fix: detect lightbulb only once

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -44,7 +44,7 @@ class Client extends EventEmitter {
             this.emit('message', message)
 
             const data = qs.parse(message.toString(), '\r\n', ': ')
-            const light = this.lights.find(yee => yee.id === data['id'])
+            const light = this.lights.find(yee => yee.id === parseInt(data['id'], 16))
 
             if (!light) {
                 const location = data['Location']


### PR DESCRIPTION
This PR is related to this issue.
The id is not parsed here, so the stored lightbulb id cannot never match the detected lightbulb id. 
https://github.com/thomas-bouvier/yeelight-node/issues/7